### PR TITLE
fix: add `type` to the dependency list of data loading hook

### DIFF
--- a/src/DocumentListQuery.js
+++ b/src/DocumentListQuery.js
@@ -63,7 +63,7 @@ export default function DocumentListQuery({type}) {
 
     return () => subscription?.unsubscribe()
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [])
+  }, [type])
 
   const unorderedDataCount = useMemo(
     () => (data.length ? data.filter((doc) => !doc[ORDER_FIELD_NAME]).length : 0),


### PR DESCRIPTION
This change adds `type` to the dependency list of the query loading hook in `DocumentListQuery`. This makes sure the list items are reloaded as the user navigates between different orderable lists with a different `type`.