### PR TITLE
highlight duplicate orders, change click handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 Drag-and-drop Document Ordering without leaving the Editing surface.
 
-![2021-09-28 16 33 51](https://user-images.githubusercontent.com/9684022/135118990-5e20ac68-d010-40c2-a722-f596089c631a.gif)
-
-📹 [Installation Walkthrough Video](https://www.loom.com/share/309f21cce37e44739365a94d425e2e19) (including a bug that is now fixed 😅)
+![2022-04-26 12 23 39](https://user-images.githubusercontent.com/9684022/165289621-dbd9d841-028e-40c7-be14-7398fcdb1210.gif)
 
 This plugin aims to be OS-like in that you can select and move multiple documents by holding `shift` and clicking a second item, and toggling on/off selections by holding `command/control`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/orderable-document-list",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Drag-and-drop Document Ordering without leaving the Editing surface",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Document.js
+++ b/src/Document.js
@@ -1,15 +1,8 @@
 import PropTypes from 'prop-types'
 // eslint-disable-next-line no-unused-vars
-import React, {useCallback, useContext, useMemo} from 'react'
-import {
-  DragHandleIcon,
-  ChevronUpIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-  EditIcon,
-} from '@sanity/icons'
+import React, {useContext} from 'react'
+import {DragHandleIcon, ChevronUpIcon, ChevronDownIcon} from '@sanity/icons'
 import {Text, Flex, Box, Button} from '@sanity/ui'
-import {usePaneRouter} from '@sanity/desk-tool'
 import Preview from 'part:@sanity/base/preview'
 import schema from 'part:@sanity/base/schema'
 
@@ -55,13 +48,6 @@ export default function Document({doc, increment, entities, handleSelect, index,
           </Box>
         </Flex>
       </Button>
-      <Box paddingX={3} style={{flexShrink: 0}}>
-        <ChildEditLink id={doc._id}>
-          <Text fontSize={4}>
-            {doc._id.startsWith(`drafts.`) ? <EditIcon /> : <ChevronRightIcon />}
-          </Text>
-        </ChildEditLink>
-      </Box>
     </Flex>
   )
 }
@@ -81,36 +67,4 @@ Document.propTypes = {
   index: PropTypes.number.isRequired,
   isFirst: PropTypes.bool.isRequired,
   isLast: PropTypes.bool.isRequired,
-}
-
-const ChildEditLink = ({id, children}) => {
-  const router = usePaneRouter()
-  const {ChildLink, routerPanesState} = router
-
-  // Is this document currently being edited
-  const isOpen = useMemo(
-    () => routerPanesState.some((pane) => pane[0]?.id === id.replace(`drafts.`, ``)),
-    [id, routerPanesState]
-  )
-
-  const Link = useCallback(
-    (linkProps) => <ChildLink {...linkProps} childId={id.replace(`drafts.`, ``)} />,
-    [ChildLink, id]
-  )
-
-  return (
-    <Button
-      as={Link}
-      mode={isOpen ? `default` : `ghost`}
-      tone={isOpen ? `primary` : `transparent`}
-      padding={2}
-    >
-      {children}
-    </Button>
-  )
-}
-
-ChildEditLink.propTypes = {
-  id: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
 }

--- a/src/DocumentListQuery.js
+++ b/src/DocumentListQuery.js
@@ -13,7 +13,7 @@ const client = sanityClient.withConfig({
 
 export default function DocumentListQuery({type}) {
   const [isLoading, setIsLoading] = useState(true)
-  const [isUpdating, setIsUpdating] = useState(false)
+  const [listIsUpdating, setListIsUpdating] = useState(false)
   const [data, setData] = useState([])
 
   useEffect(() => {
@@ -57,7 +57,7 @@ export default function DocumentListQuery({type}) {
     }
 
     // Get data but only if a document isn't being patched or we don't yet have data
-    if (!isUpdating && !data.length) {
+    if (!listIsUpdating && !data.length) {
       prepareData()
     }
 
@@ -86,7 +86,12 @@ export default function DocumentListQuery({type}) {
         </Feedback>
       )}
       <Box padding={1}>
-        <DraggableList data={data} isUpdating={isUpdating} setIsUpdating={setIsUpdating} />
+        <DraggableList
+          data={data}
+          type={type}
+          listIsUpdating={listIsUpdating}
+          setListIsUpdating={setListIsUpdating}
+        />
       </Box>
     </Stack>
   )

--- a/src/helpers/reorderDocuments.js
+++ b/src/helpers/reorderDocuments.js
@@ -88,18 +88,6 @@ export const reorderDocuments = ({entities, selectedIds, source, destination, de
           betweenRank = isMovingUp ? betweenRank.between(curRank) : betweenRank.between(nextRank)
         }
 
-        // This data is not actually used by the plugin
-        // console.table(
-        //   createManifest({
-        //     entities,
-        //     selectedItems,
-        //     isMovingUp,
-        //     curIndex,
-        //     nextIndex,
-        //     prevIndex,
-        //   })
-        // )
-
         return {
           // The `all` array gets sorted by order field later anyway
           // so that this probably isn't necessary ¯\_(ツ)_/¯


### PR DESCRIPTION
![2022-04-26 12 23 39](https://user-images.githubusercontent.com/9684022/165289621-dbd9d841-028e-40c7-be14-7398fcdb1210.gif)

Version `0.0.6` changes the UX to mirror Mac OS Finder in Column view. Clicking a document without modifier keys (shift/ctrl/cmd) will open a document and set the selection to just that ID. Modifier keys will during click will not change the currently opened document.