### PR TITLE
Fix scrollbars on DocumentListQuery.tsx style

### DIFF
--- a/src/DocumentListQuery.tsx
+++ b/src/DocumentListQuery.tsx
@@ -93,7 +93,7 @@ export default function DocumentListQuery({
     )
 
   return (
-    <Stack space={1} style={{overflow: `scroll`, height: `100%`}}>
+    <Stack space={1} style={{overflow: `auto`, height: `100%`}}>
       {unorderedDataCount > 0 && (
         <Feedback>
           {unorderedDataCount}/{data.length} Documents have no Order. Select{' '}


### PR DESCRIPTION
Due to the style set to "overflow: scroll" the scrollbars would appear all the time cluttering the interface, this small change should fix it.