### PR TITLE
Configurable option to allow new items to appear at top of list instead of bottom

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:sanity-io/orderable-document-list.git"
+    "url": "github.com/the-good-work/orderable-document-list.git"
   },
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -1,5 +1,5 @@
 import {useContext, useMemo, type ReactNode} from 'react'
-import {ChevronDownIcon, ChevronUpIcon, DragHandleIcon} from '@sanity/icons'
+import {ChevronDownIcon, ChevronUpIcon, DoubleChevronUpIcon, DragHandleIcon} from '@sanity/icons'
 import {AvatarCounter, Card, Box, Button, Flex, Text} from '@sanity/ui'
 import {useSchema, SchemaType, PreviewCard, Preview} from 'sanity'
 import {usePaneRouter} from 'sanity/desk'
@@ -87,6 +87,15 @@ export default function Document({
               // eslint-disable-next-line react/jsx-no-bind
               onClick={() => increment(index, index + 1, doc._id, entities)}
               icon={ChevronDownIcon}
+            />
+
+            <Button
+              padding={2}
+              mode="ghost"
+              disabled={isFirst}
+              // eslint-disable-next-line react/jsx-no-bind
+              onClick={() => increment(index, 0, doc._id, entities)}
+              icon={DoubleChevronUpIcon}
             />
           </Flex>
         )}


### PR DESCRIPTION
In our use case, on certain content displays it is more useful to have items appear at the start of the list by default, instead of the end as it is currently. 

I also added a button to push item to the start on the "Toggle Increment" buttons. 