### PR TITLE
Config option to insert new item at start of list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/orderable-document-list",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/orderable-document-list",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sanity/orderable-document-list",
+  "name": "@thegoodwork/orderable-document-list",
   "version": "1.1.0",
   "description": "Drag-and-drop Document Ordering without leaving the Editing surface",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@thegoodwork/orderable-document-list",
-  "version": "1.1.1",
+  "name": "@sanity/orderable-document-list",
+  "version": "1.1.0",
   "description": "Drag-and-drop Document Ordering without leaving the Editing surface",
   "keywords": [
     "sanity",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/the-good-work/orderable-document-list.git"
+    "url": "git@github.com:sanity-io/orderable-document-list.git"
   },
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegoodwork/orderable-document-list",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Drag-and-drop Document Ordering without leaving the Editing surface",
   "keywords": [
     "sanity",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:sanity-io/orderable-document-list.git"
+    "url": "github.com/the-good-work/orderable-document-list.git"
   },
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/src/Document.tsx
+++ b/src/Document.tsx
@@ -1,5 +1,5 @@
 import {useContext, useMemo, type ReactNode} from 'react'
-import {ChevronDownIcon, ChevronUpIcon, DragHandleIcon} from '@sanity/icons'
+import {ChevronDownIcon, ChevronUpIcon, DoubleChevronUpIcon, DragHandleIcon} from '@sanity/icons'
 import {AvatarCounter, Card, Box, Button, Flex, Text} from '@sanity/ui'
 import {useSchema, SchemaType, PreviewCard, Preview} from 'sanity'
 import {usePaneRouter} from 'sanity/desk'
@@ -87,6 +87,15 @@ export default function Document({
               // eslint-disable-next-line react/jsx-no-bind
               onClick={() => increment(index, index + 1, doc._id, entities)}
               icon={ChevronDownIcon}
+            />
+
+            <Button
+              padding={2}
+              mode="ghost"
+              disabled={isFirst}
+              // eslint-disable-next-line react/jsx-no-bind
+              onClick={() => increment(index, 0, doc._id, entities)}
+              icon={DoubleChevronUpIcon}
             />
           </Flex>
         )}

--- a/src/helpers/prevRank.ts
+++ b/src/helpers/prevRank.ts
@@ -1,0 +1,10 @@
+import {LexoRank} from 'lexorank'
+
+// Use in initial value field by passing in the rank value of the last document
+// If not value passed, generate a sensibly low rank
+export default function prevRank(lastRankValue = ``): string {
+  const lastRank = lastRankValue ? LexoRank.parse(lastRankValue) : LexoRank.min()
+  const nextRank = lastRank.genPrev()
+
+  return nextRank.toString()
+}


### PR DESCRIPTION
In our use case, on certain content displays it is useful to have new items appear at the start of the list by default, instead of the end as it is currently.

I also added a button to push item to the start on the "Toggle Increment" buttons.