### PR TITLE
Enhancements to OrderableDocumentList: Custom createIntent Handling & menuItems injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ export default defineConfig({
               params: {
                 lang: 'en_US',
               },
+              createIntent: false, // do not add an option for item creation
+              menuItems: [], // allow an array of `S.menuItem()` to be injected to orderable document list menu
               // pass from the structure callback params above
               S,
               context,

--- a/src/desk-structure/orderableDocumentListDeskItem.ts
+++ b/src/desk-structure/orderableDocumentListDeskItem.ts
@@ -2,7 +2,7 @@ import {GenerateIcon, SortIcon} from '@sanity/icons'
 import type {ConfigContext} from 'sanity'
 
 import {ComponentType} from 'react'
-import {StructureBuilder, type ListItem} from 'sanity/desk'
+import {StructureBuilder, type ListItem, type MenuItem} from 'sanity/desk'
 import OrderableDocumentList from '../OrderableDocumentList'
 
 export interface OrderableListConfig {
@@ -12,6 +12,8 @@ export interface OrderableListConfig {
   icon?: ComponentType
   params?: Record<string, unknown>
   filter?: string
+  menuItems?: MenuItem[]
+  createIntent?: boolean
   context: ConfigContext
   S: StructureBuilder
 }
@@ -25,7 +27,7 @@ export function orderableDocumentListDeskItem(config: OrderableListConfig): List
     `)
   }
 
-  const {type, filter, params, title, icon, id, context, S} = config
+  const {type, filter, menuItems = [], createIntent, params, title, icon, id, context, S} = config
   const {schema, getClient} = context
   const client = getClient({apiVersion: '2021-09-01'})
 
@@ -34,6 +36,14 @@ export function orderableDocumentListDeskItem(config: OrderableListConfig): List
   const listIcon = icon ?? SortIcon
   const typeTitle = schema.get(type)?.title ?? type
 
+  if (createIntent !== false) {
+    menuItems.push(
+      S.menuItem()
+        .title(`Create new ${typeTitle}`)
+        .intent({type: 'create', params: {type}})
+        .serialize()
+    )
+  }
   return S.listItem()
     .title(listTitle)
     .id(listId)
@@ -49,10 +59,7 @@ export function orderableDocumentListDeskItem(config: OrderableListConfig): List
         component: OrderableDocumentList,
         options: {type, filter, params, client},
         menuItems: [
-          S.menuItem()
-            .title(`Create new ${typeTitle}`)
-            .intent({type: 'create', params: {type}})
-            .serialize(),
+          ...menuItems,
           S.menuItem().title(`Reset Order`).icon(GenerateIcon).action(`resetOrder`).serialize(),
           S.menuItem()
             .title(`Toggle Increments`)


### PR DESCRIPTION
This PR introduces enhancements to the Orderable Document List menu of the Sanity plugin, allowing for greater customization. Currently, the menu is not customizable and defaults to [three options](https://github.com/sanity-io/orderable-document-list/blob/3149cae83ef5e012d4e0f8adad4b25c1b3326aac/src/desk-structure/orderableDocumentListDeskItem.ts#L51C10-L51C10): create, reset, and toggle increment. This update addresses the need for more flexible menu options, particularly in cases like using Sanity alongside of Shopify where the creation of ProductVariants should strictly be controlled by Shopify. When the listing is created as `S.listItem()`with a `canHandleIntent` function, ProductVariants creation in Sanity can be disabled; the same cannot be done when ProductVariants is listed using OrderableDocumentList (for custom sorting of variants).

# Changes:

## createIntent:

`boolean`, defaults to `true`.

### Purpose 

Allows control over the 'create' option in the menu.

### Use Case:

In scenarios where records are managed externally (like Shopify) and synced to Sanity, the ability to disable the 'create' option prevents unintended creation of records.


## menuItems:

`array`, defaults to `[]`.

### Purpose: 

Allows the injection of additional menu items (`S.menuItem()`) into the Orderable Document List menu.

### Benefit: 

This feature provides flexibility to add more options to the menu, tailored to specific project requirements.
