### PR TITLE
Add option to add new documents on top

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Additionally, pass in overrides for the field, such as making it visible by pass
 
 You cannot override the `name`, `type` or `initialValue` attributes.
 
+You can configure the placement of new documents by setting `newItemPosition` to `before` (defaults to `after`).
+
 ```js
 // sanity.config.js
 import {defineConfig} from "sanity";
@@ -136,8 +138,11 @@ export default defineConfig({
                         // Minimum required configuration
                         orderRankField({ type: "category" }),
 
+                        // OR placing new documents on top
+                        orderRankField({ type: "category", newItemPosition: "before" }),
+
                         // OR you can override _some_ of the field settings
-                        orderRankField({ type: 'category', hidden: false }),
+                        orderRankField({ type: "category", hidden: false }),
 
                         // ...all other fields
                     ],
@@ -153,8 +158,8 @@ export default defineConfig({
 On first load, your Document list will not have any Order. You can select "Reset Order" from the menu in the top right of the list.
 You can also re-run this at any time.
 
-The `orderRankField` will query the last Document to set an `initialValue` to come after it.
-New Documents always start at the end of the Ordered list.
+The `orderRankField` will query the last/first Document to set an `initialValue` to come after/before it.
+The placement of new documents can be configured by `newItemPosition` on the `orderRankField` in the document.
 
 ## Querying Ordered Documents
 

--- a/src/desk-structure/orderableDocumentListDeskItem.ts
+++ b/src/desk-structure/orderableDocumentListDeskItem.ts
@@ -4,6 +4,7 @@ import type {ConfigContext} from 'sanity'
 import {ComponentType} from 'react'
 import {StructureBuilder, type ListItem, type MenuItem} from 'sanity/desk'
 import OrderableDocumentList from '../OrderableDocumentList'
+import {API_VERSION} from '../helpers/constants'
 
 export interface OrderableListConfig {
   type: string
@@ -29,7 +30,7 @@ export function orderableDocumentListDeskItem(config: OrderableListConfig): List
 
   const {type, filter, menuItems = [], createIntent, params, title, icon, id, context, S} = config
   const {schema, getClient} = context
-  const client = getClient({apiVersion: '2021-09-01'})
+  const client = getClient({apiVersion: API_VERSION})
 
   const listTitle = title ?? `Orderable ${type}`
   const listId = id ?? `orderable-${type}`

--- a/src/helpers/client.ts
+++ b/src/helpers/client.ts
@@ -1,5 +1,6 @@
 import {useClient} from 'sanity'
+import {API_VERSION} from './constants'
 
 export function useSanityClient() {
-  return useClient({apiVersion: '2021-09-01'})
+  return useClient({apiVersion: API_VERSION})
 }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,1 +1,3 @@
 export const ORDER_FIELD_NAME = `orderRank` as const
+
+export const API_VERSION = `2021-09-01` as const

--- a/src/helpers/initialRank.ts
+++ b/src/helpers/initialRank.ts
@@ -1,10 +1,15 @@
 import {LexoRank} from 'lexorank'
+import {NewItemPosition} from '../types'
 
 // Use in initial value field by passing in the rank value of the last document
 // If not value passed, generate a sensibly low rank
-export default function initialRank(lastRankValue = ``): string {
-  const lastRank = lastRankValue ? LexoRank.parse(lastRankValue) : LexoRank.min()
-  const nextRank = lastRank.genNext().genNext()
+export default function initialRank(
+  compareRankValue = ``,
+  newItemPosition: NewItemPosition = 'after'
+): string {
+  const compareRank = compareRankValue ? LexoRank.parse(compareRankValue) : LexoRank.min()
+  const rank =
+    newItemPosition === 'before' ? compareRank.genPrev().genPrev() : compareRank.genNext().genNext()
 
-  return nextRank.toString()
+  return rank.toString()
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,3 +6,5 @@ export interface SanityDocumentWithOrder extends SanityDocument {
   [ORDER_FIELD_NAME]?: string
   hasPublished?: boolean
 }
+
+export type NewItemPosition = 'after' | 'before'


### PR DESCRIPTION
Add an option to the `orderRankField` for placement of new documents and updated README for instructions how to use the feature.