### PR TITLE
fix: respect filter when resetting document order

### DIFF
--- a/src/DocumentListQuery.tsx
+++ b/src/DocumentListQuery.tsx
@@ -5,27 +5,13 @@ import {useListeningQuery, Feedback} from 'sanity-plugin-utils'
 import {DraggableList} from './DraggableList'
 import {ORDER_FIELD_NAME} from './helpers/constants'
 import type {SanityDocumentWithOrder} from './types'
+import {DocumentListQueryProps, getDocumentQuery} from './helpers/query'
 
-export interface DocumentListQueryProps {
-  type: string
-  filter?: string
-  params?: Record<string, unknown>
-}
-
-const DEFAULT_PARAMS = {}
-
-export function DocumentListQuery({type, filter, params = DEFAULT_PARAMS}: DocumentListQueryProps) {
+export function DocumentListQuery(props: DocumentListQueryProps) {
   const [listIsUpdating, setListIsUpdating] = useState(false)
   const [data, setData] = useState<SanityDocumentWithOrder[] | null>([])
 
-  const query = `*[_type == $type ${filter ? `&& ${filter}` : ''}]|order(@[$order] asc){
-    _id, _type, ${ORDER_FIELD_NAME}
-  }`
-  const queryParams = {
-    ...params,
-    type,
-    order: ORDER_FIELD_NAME,
-  }
+  const {query, queryParams} = getDocumentQuery(props)
 
   const {
     data: _queryData,

--- a/src/OrderableDocumentList.tsx
+++ b/src/OrderableDocumentList.tsx
@@ -45,7 +45,7 @@ export class OrderableDocumentList extends Component<OrderableDocumentListProps,
         },
       }))
 
-      const update = await resetOrder(this.props.options.type, this.props.options.client)
+      const update = await resetOrder(this.props.options)
 
       const reorderWasSuccessful = update?.results?.length
 

--- a/src/helpers/query.ts
+++ b/src/helpers/query.ts
@@ -1,0 +1,33 @@
+import {ORDER_FIELD_NAME} from './constants'
+
+export interface DocumentListQueryProps {
+  type: string
+  filter?: string
+  params?: Record<string, unknown>
+}
+
+export interface DocumentListQueryResult {
+  query: string
+  queryParams: Record<string, string | number | boolean | string[]>
+}
+
+const DEFAULT_PARAMS = {}
+
+export function getDocumentQuery({
+  type,
+  filter,
+  params = DEFAULT_PARAMS,
+}: DocumentListQueryProps): DocumentListQueryResult {
+  const querySelect = `*[_type == $type ${filter ? `&& ${filter}` : ''}]`
+  const queryOrder = `|order(@[$order] asc)`
+  const queryFields = `{_id, _type, ${ORDER_FIELD_NAME}}`
+
+  const query = `${querySelect}${queryOrder}${queryFields}`
+  const queryParams = {
+    ...params,
+    type,
+    order: ORDER_FIELD_NAME,
+  }
+
+  return {query, queryParams}
+}

--- a/src/helpers/resetOrder.ts
+++ b/src/helpers/resetOrder.ts
@@ -1,15 +1,17 @@
 import {LexoRank} from 'lexorank'
 import type {MultipleMutationResult, SanityClient} from '@sanity/client'
 import {ORDER_FIELD_NAME} from './constants'
+import {DocumentListQueryProps, getDocumentQuery} from './query'
+
+export interface ResetOrderParams extends DocumentListQueryProps {
+  client: SanityClient
+}
 
 // Function to wipe and re-do ordering with LexoRank
 // Will at least attempt to start with the current order
-export async function resetOrder(
-  type: string,
-  client: SanityClient,
-): Promise<MultipleMutationResult | null> {
-  const query = `*[_type == $type]|order(@[$order] asc)._id`
-  const queryParams = {type, order: ORDER_FIELD_NAME}
+export async function resetOrder(params: ResetOrderParams): Promise<MultipleMutationResult | null> {
+  const {client, ...queryProps} = params
+  const {query, queryParams} = getDocumentQuery(queryProps)
   const documentIds = await client.fetch<Array<string>>(query, queryParams, {
     tag: 'orderable-document-list.reset-order',
   })


### PR DESCRIPTION
Respect the document filter when resetting the order of all documents. Fixes #52 

The query for the document list implemented the filter parameter, but the reset functionality was missing the same. This PR consolidates the building of the query into a single place to prevent this in the future, and uses that builder function for both the list and reset query.
