### PR TITLE
Add example of rest of document types for desk list

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ export default defineConfig({
               context,
             }),
 
-            // ... all other desk items
+            // ... all other desk items, e.g. all other document types not already included
+            // @see https://www.sanity.io/docs/studio/structure-builder-cheat-sheet#k4eb3b1891dc2
+            ...S.documentTypeListItems().filter((item) => !(['category', 'project'].includes(item.getId())))
           ])
       },
     }),


### PR DESCRIPTION
Add an example of including the document types that have not been included as orderable to get started so that document types don't disappear when people first try it out without having dealt with Desk lists before