### PR TITLE
fix: use sync visibility for reorder transaction to prevent visual reset

### DIFF
--- a/src/DraggableList.tsx
+++ b/src/DraggableList.tsx
@@ -123,7 +123,7 @@ export function DraggableList({data, listIsUpdating, setListIsUpdating}: Draggab
 
       try {
         const updated = await transaction.commit({
-          visibility: 'async',
+          visibility: 'sync',
           tag: 'orderable-document-list.reorder',
         })
         clearSelected()


### PR DESCRIPTION
## Problem

  After upgrading to Sanity v5 + React 19, dragging to reorder documents causes the list to
  visually revert to the previous order. A page refresh shows the correct order, confirming
  the backend mutation works fine.

  ### Root cause

  In `DraggableList.tsx`, `transaction.commit()` uses `visibility: 'async'`. This means the
  promise resolves before the mutation is visible in the content lake. The sequence is:

  1. User drags → optimistic update shows correct new order
  2. `commit()` resolves → `listIsUpdating` set to `false`
  3. Real-time listener re-queries → returns **stale** data (mutation not yet visible)
  4. `useEffect` applies stale data since `listIsUpdating` is already `false` → visual revert
  5. No second listener event → stays wrong until manual refresh

  This was masked in Sanity v3 but became visible with Sanity v5 due to changes in
  listener/query timing.

  ## Fix

  Change `visibility: 'async'` to `visibility: 'sync'` in the reorder transaction. This
  ensures the mutation is confirmed visible before the promise resolves, so the listener
  always reads consistent data.

  The trade-off is a slightly slower commit (waits for confirmation), but this is negligible
  for a user-initiated drag action.

  ## Test plan

  - Open an orderable document list in Sanity Studio (Sanity v5)
  - Drag a document to a new position
  - Verify the list maintains the new order without reverting
  - Verify a page refresh shows the same order