### PR TITLE
Refine intent handling in orderableDocumentListDeskItem

### DIFF
--- a/src/desk-structure/orderableDocumentListDeskItem.ts
+++ b/src/desk-structure/orderableDocumentListDeskItem.ts
@@ -57,7 +57,7 @@ export function orderableDocumentListDeskItem(config: OrderableListConfig): List
     .child(
       Object.assign(
         S.documentTypeList(type)
-          .canHandleIntent(() => !!createIntent)
+          .canHandleIntent(() => !!createIntent && params.type === type)
           .serialize(),
         {
           // Prevents the component from re-rendering when switching documents


### PR DESCRIPTION
### Description

Fix issue #127 
> If I enable createIntent, and try to create another document in my Admin view, it redirects me to the type that uses orderable-document-list, where it seems the create call is being hijacked by the library.
